### PR TITLE
Fixed some bugs

### DIFF
--- a/include/RingBuffer.h
+++ b/include/RingBuffer.h
@@ -171,7 +171,11 @@ public:
      */
     void Skip(unsigned int num_reads)
     {
-        read_position = (read_position + num_reads) % LENGTH;
+    	if ((read_position + num_reads) % LENGTH <= write_position){
+    		read_position = (read_position + num_reads) % LENGTH;
+    	}else{
+    		read_position = write_position;
+    	}
     }
 
     bool Overrun()

--- a/include/RingBuffer.h
+++ b/include/RingBuffer.h
@@ -160,6 +160,8 @@ public:
             block.SetLength(max_num_reads);
         }
 
+        read_position = (read_position + num_reads_requested) % LENGTH;
+
         return block;
     }
 


### PR DESCRIPTION
In the original version , the code:
```
#include <iostream>
using namespace std;

#include "RingBuffer.h"

RingBuffer<10, int> rb;

int main() {
	for (int i = 0; i < 8; ++i) {
		rb.Append(i);
	}

	while (rb.Available()) {
		cout << rb.Read(1).At(0) << endl;
		//rb.Skip(1);
	}



	return 0;
}
```
falls into an infinite loop, because the Read method does not move the buffer read pointer to the next position. This can be done using the Skip method, of course, but I think it's not right. I fixed it.
I also fixed the Skip method itself, because in the original version it did not control the input parameter to see if it could be more than the available amount of data to read. I corrected that too

